### PR TITLE
Add rotation property to Frame class

### DIFF
--- a/src/artisynth/core/mechmodels/Frame.java
+++ b/src/artisynth/core/mechmodels/Frame.java
@@ -79,7 +79,7 @@ public class Frame extends DynamicComponentBase
 
    //protected MeshComponentList<RigidMeshComp> myMeshList;
 
-   static {
+   static {                 
       myProps.add (
          "renderProps * *", "render properties", null);
       myProps.add (
@@ -88,6 +88,8 @@ public class Frame extends DynamicComponentBase
          "position", "position of the body coordinate frame",null,"NW");
       myProps.add (
          "orientation", "orientation of the body coordinate frame", null, "NW");
+      myProps.add (
+         "rotation", "rotation of the body coordinate frame",null,"NW");
       myProps.add ("velocity * *", "velocity state", null, "NW");
       
       myProps.add (


### PR DESCRIPTION
The Frame class is missing the `rotation` property, needed for probe input of rotation as a quaternion.