### PR TITLE
Bring the enable flag up to QPTerm

### DIFF
--- a/src/artisynth/core/inverse/LeastSquaresTermBase.java
+++ b/src/artisynth/core/inverse/LeastSquaresTermBase.java
@@ -19,15 +19,11 @@ public abstract class LeastSquaresTermBase extends QPTermBase
    protected VectorNd f = new VectorNd(); //right hand side
   
    public static final double defaultWeight = 1;
-   
-   public static final boolean DEFAULT_ENABLED = true;
-   private boolean enabled = DEFAULT_ENABLED;
 
    public static PropertyList myProps =
       new PropertyList (LeastSquaresTermBase.class, QPTermBase.class);
 
    static {
-      myProps.add ("enabled isEnabled setEnabled", "enable this constraint", DEFAULT_ENABLED);
    }
    
    public PropertyList getAllPropertyInfo() {
@@ -93,11 +89,5 @@ public abstract class LeastSquaresTermBase extends QPTermBase
    }
    
 
-   public boolean isEnabled () {
-      return enabled;
-   }
 
-   public void setEnabled (boolean enabled) {
-      this.enabled = enabled;
-   }
 }

--- a/src/artisynth/core/inverse/MotionTargetTerm.java
+++ b/src/artisynth/core/inverse/MotionTargetTerm.java
@@ -68,7 +68,6 @@ public class MotionTargetTerm extends LeastSquaresTermBase {
    protected boolean normalizeH = DEFAULT_NORMALIZE_H;
    
    boolean debug = false;
-   boolean enabled = true;
    // Avoids recomputation of the velocity Jacobian. This actually gives
    // incorrect results and is provided for comparison with legacy code only.
    public static boolean keepVelocityJacobianConstant = false;
@@ -327,16 +326,6 @@ public class MotionTargetTerm extends LeastSquaresTermBase {
       prevTargetPos.set (myTargetPos);
    }
 
-   public boolean isEnabled() {
-      return enabled;
-   }
-
-   public void setEnabled(boolean enabled) {
-      this.enabled = enabled;
-      // if (myMech != null && myMech instanceof MechModel) {
-      // ((MechModel)myMech).setDynamicsEnabled(enabled);
-      // }
-   }
 
    /**
     * get current velocity projected into target velocity subspace

--- a/src/artisynth/core/inverse/QPCostFunction.java
+++ b/src/artisynth/core/inverse/QPCostFunction.java
@@ -83,7 +83,8 @@ public class QPCostFunction {
       Q.setZero ();
       P.setZero ();
       for (QPTerm term : myCostTerms) {
-         term.getQP (Q,P,t0,t1);
+         if (term.isEnabled ())
+            term.getQP (Q,P,t0,t1);
       }
       int rowoff = 0;
       for (LeastSquaresTerm term : myInequalityTerms) {

--- a/src/artisynth/core/inverse/QPTerm.java
+++ b/src/artisynth/core/inverse/QPTerm.java
@@ -20,4 +20,11 @@ public interface QPTerm extends HasProperties {
     * @param t1 time at end of step
     */
    public void getQP(MatrixNd Q, VectorNd P, double t0, double t1);
+   
+   /**
+    * Returns that enabled status of this term, for use if term is 
+    * an inequality / equality constraint
+    * @return is this term enabled
+    */
+   public boolean isEnabled();
 }

--- a/src/artisynth/core/inverse/QPTermBase.java
+++ b/src/artisynth/core/inverse/QPTermBase.java
@@ -15,9 +15,14 @@ public abstract class QPTermBase implements QPTerm, HasProperties {
 
    public static final double defaultWeight = 1;
    
+   public static final boolean DEFAULT_ENABLED = true;
+   protected boolean enabled = DEFAULT_ENABLED;
+   
+   
    public static PropertyList myProps = new PropertyList (QPTermBase.class);
 
    static {
+      myProps.add ("enabled isEnabled setEnabled", "enable this term", DEFAULT_ENABLED);
       myProps.add ("weight * *", "weighting factor for this optimization term", 1);
    }
       
@@ -43,6 +48,14 @@ public abstract class QPTermBase implements QPTerm, HasProperties {
    
    public double getWeight() {
       return myWeight;
+   }
+   
+   public boolean isEnabled () {
+      return enabled;
+   }
+
+   public void setEnabled (boolean enabled) {
+      this.enabled = enabled;
    }
    
    public int getSize() {


### PR DESCRIPTION
Allows to enable/disable any term from the cost function or the constraint set. Prior to this PR, this was affecting only the constraint, which is error-prone from user point of view.