### PR TITLE
Close the movie metadata reader

### DIFF
--- a/src/artisynth/core/moviemaker/MakeMovieFromData.java
+++ b/src/artisynth/core/moviemaker/MakeMovieFromData.java
@@ -44,23 +44,22 @@ public class MakeMovieFromData implements ControllerListener, DataSinkListener {
 
       String fileInfo = dataPath + "/info.txt";
       
-      BufferedReader in = new BufferedReader (new FileReader (fileInfo));
-      
-      String line = in.readLine ();
-      nFrames = Integer.parseInt (line.substring (line.lastIndexOf (' ') + 1));
-      line = in.readLine ();
-      width = Integer.parseInt (line.substring (line.lastIndexOf (' ') + 1));
-      line = in.readLine ();
-      height = Integer.parseInt (line.substring (line.lastIndexOf (' ') + 1));
-      line = in.readLine ();
-      frameRate = Double.parseDouble (line.substring(line.lastIndexOf (' ') + 1));
+      try (BufferedReader in = new BufferedReader (new FileReader (fileInfo))) {
+         String line = in.readLine ();
+         nFrames = Integer.parseInt (line.substring (line.lastIndexOf (' ') + 1));
+         line = in.readLine ();
+         width = Integer.parseInt (line.substring (line.lastIndexOf (' ') + 1));
+         line = in.readLine ();
+         height = Integer.parseInt (line.substring (line.lastIndexOf (' ') + 1));
+         line = in.readLine ();
+         frameRate = Double.parseDouble (line.substring(line.lastIndexOf (' ') + 1));
+      }
       
       myMovieMaker = maker;  // used for logging messages
 
       MediaLocator oml;
       if ((oml = createMediaLocator("file:"+dataPath + "/" + fileName)) == null) {
          myMovieMaker.println ("Cannot build media locator from: " + fileName);
-         in.close();
          return false;
       }
       myMovieMaker.println ("output file = " + fileName);
@@ -70,7 +69,6 @@ public class MakeMovieFromData implements ControllerListener, DataSinkListener {
          inputFiles.addElement (frameFileNames[i]);
       }
       boolean status = doIt (width, height, (int) frameRate, inputFiles, oml);
-      in.close();
       return status;
    }
 


### PR DESCRIPTION
Hi. We are researchers from Mahidol University, Thailand, and the State University of Ceará, Brazil, working on a research project for improving open-source projects by using the latest accepted answer from Stack Overflow that matched your code snippet. We found this recommendation for improving your code from https://stackoverflow.com/a/6236324.

Note: Our study is approved by the Institutional Review Board of Mahidol University. You can find the participant information sheet explaining this study https://drive.google.com/file/d/1ml5AqrtWQ9pnifTQyTFTcWQmwp6RuPA7/view?usp=sharing.

----

## Proposed change

Use try-with-resources when reading movie metadata so the file handle is closed on success and failure.

<!-- Include the Testing section only when a relevant test exists and was run. Otherwise remove this comment and the entire section below. -->
